### PR TITLE
Ignore node_modules when creating Docker images

### DIFF
--- a/server/question-service/.dockerignore
+++ b/server/question-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/server/user-service/.dockerignore
+++ b/server/user-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
* add `.dockerignore ` file to prevent `node_modules` from being copied over when building image