### PR TITLE
add local mongodb docker file & instructions to run

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -14,6 +14,7 @@ ENV=PROD
 PORT_USER=3001
 # MongoDB
 DB_URI_USER=''
+
 # JWT secret
 JWT_SECRET=you-can-replace-this-with-your-own-secret
 
@@ -23,3 +24,9 @@ JWT_SECRET=you-can-replace-this-with-your-own-secret
 PORT_QUESTION=3002
 # MongoDB
 DB_URI_QUESTION=''
+
+# -----------
+# For local mongodb instance, uncomment BOTH:
+
+# DB_URI_USER='mongodb://mongo:27018/user'
+# DB_URI_QUESTION='mongodb://mongo:27018/question'

--- a/server/README.md
+++ b/server/README.md
@@ -15,6 +15,12 @@ docker compose build
 docker compose up -d
 ```
 
+To run Mongodb through a local instance:
+```sh
+docker compose -f docker-compose.local.yml build
+docker compose -f docker-compose.local.yml up -d
+```
+
 ## Default port numbers
 
 | **Service** | **Port** |

--- a/server/docker-compose.local.yml
+++ b/server/docker-compose.local.yml
@@ -1,0 +1,43 @@
+name: local-mongo-instance
+services:
+  user:
+    build:
+      context: ./user-service
+      dockerfile: Dockerfile
+      args:
+        - PORT=${PORT_USER}
+    ports:
+      - ${PORT_USER}:${PORT_USER}
+    environment:
+      - ENV
+      - DB_CLOUD_URI=${DB_URI_USER}
+      - DB_LOCAL_URI=${DB_URI_USER}
+      - JWT_SECRET
+    depends_on:
+      - mongo
+
+  questions:
+    build:
+      context: ./question-service
+      dockerfile: Dockerfile
+      args:
+        - PORT=${PORT_QUESTION}
+    ports:
+      - ${PORT_QUESTION}:${PORT_QUESTION}
+    environment:
+      - ENV
+      - DB_CLOUD_URI=${DB_URI_QUESTION}
+    depends_on:
+      - mongo
+  
+  mongo:
+    container_name: mongo
+    image: mongo
+    command: mongod --port 27018
+    ports:
+      - "27018:27018"
+    volumes:
+      - mongo:/data/db
+
+volumes:
+  mongo:


### PR DESCRIPTION
new docker compose file that dodges school wifi blocking the port that the cloud db runs on. done through running a local mongodb instance on 27018 port instead. 

Just need to uncomment the code block at the end of the .env.template file and run the correct command (see `./server/README.md`).

The data stored within the local instance should be kept between builds.